### PR TITLE
Bundle script into executable with dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 # production
 manifest.webapp
 /build
+/dist
 *.zip
 
 # misc

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ manifest.webapp
 /build
 /dist
 *.zip
+metadata-synchronization-server.js
 
 # misc
 .DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,4 @@
 package.json
+build/
+dist/
+metadata-synchronization-server.js

--- a/README.md
+++ b/README.md
@@ -4,7 +4,25 @@
 $ yarn install
 ```
 
-File `app-config.json` must be created. If no configuration file is supplied the following is used as a placeholder:
+## Development
+
+Start development server:
+
+```
+$ yarn start
+```
+
+## Build executable
+
+```
+$ yarn dist
+```
+
+This will produce a bundled executable ```metadata-synchronization-server.js``` file that can be executed with ```node```.
+
+## Configuration file
+
+File `app-config.json` must be provided. If no configuration file is supplied the following is used as a placeholder:
 
 ```json
 {
@@ -14,18 +32,4 @@ File `app-config.json` must be created. If no configuration file is supplied the
     "password": "district"
 }
 
-```
-
-## Development
-
-Start development server:
-
-```
-$ yarn start
-```
-
-## Build
-
-```
-$ yarn build
 ```

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "babel-watch src --extensions \".js,.jsx,.ts,.tsx\"",
     "clean": "rimraf build",
     "build": "babel src --out-dir build --extensions \".js,.jsx,.ts,.tsx\"",
+    "dist": "yarn build && ncc build build/ -m",
     "prettify": "prettier \"{.,src}/**/*.{js,jsx,ts,tsx,json,css}\" --write"
   },
   "dependencies": {
@@ -45,6 +46,7 @@
     "@types/node-schedule": "^1.2.3",
     "@typescript-eslint/eslint-plugin": "^1.12.0",
     "@typescript-eslint/parser": "^1.12.0",
+    "@zeit/ncc": "^0.20.4",
     "babel-eslint": "^10.0.2",
     "babel-watch": "^7.0.0",
     "eslint": "^5.12.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/eyeseetea/metadata-synchronization-server.git"
   },
   "scripts": {
-    "start": "babel-watch src --extensions \".js,.jsx,.ts,.tsx\"",
+    "start": "NODE_ENV=development babel-watch src --extensions \".js,.jsx,.ts,.tsx\"",
     "clean": "rimraf build",
     "prebuild": "yarn clean",
     "build": "babel src --out-dir build --extensions \".js,.jsx,.ts,.tsx\"",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,11 @@
   "scripts": {
     "start": "babel-watch src --extensions \".js,.jsx,.ts,.tsx\"",
     "clean": "rimraf build",
+    "prebuild": "yarn clean",
     "build": "babel src --out-dir build --extensions \".js,.jsx,.ts,.tsx\"",
-    "dist": "yarn build && ncc build build/ -m",
+    "predist": "rimraf dist && yarn build",
+    "dist": "ncc build build/",
+    "postdist": "cp dist/index.js $npm_package_name.js",
     "prettify": "prettier \"{.,src}/**/*.{js,jsx,ts,tsx,json,css}\" --write"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prebuild": "yarn clean",
     "build": "babel src --out-dir build --extensions \".js,.jsx,.ts,.tsx\"",
     "predist": "rimraf dist && yarn build",
-    "dist": "ncc build build/",
+    "dist": "ncc build build/ -m",
     "postdist": "cp dist/index.js $npm_package_name.js",
     "prettify": "prettier \"{.,src}/**/*.{js,jsx,ts,tsx,json,css}\" --write"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "express": "^4.17.1",
     "lodash": "^4.17.14",
     "log4js": "^4.5.1",
-    "node-schedule": "^1.3.2"
+    "node-schedule": "^1.3.2",
+    "yargs": "^14.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.0",
@@ -47,6 +48,7 @@
     "@types/lodash": "^4.14.136",
     "@types/node": "^12.6.3",
     "@types/node-schedule": "^1.2.3",
+    "@types/yargs": "^13.0.2",
     "@typescript-eslint/eslint-plugin": "^1.12.0",
     "@typescript-eslint/parser": "^1.12.0",
     "@zeit/ncc": "^0.20.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,10 +30,10 @@ configure({
 
 const start = async (): Promise<void> => {
     let appConfig;
-    if (fs.existsSync("app-config.json")) {
-        appConfig = JSON.parse(fs.readFileSync("app-config.json", 'utf8'));
-    } else if (process.env.NODE_ENV === "development" && fs.existsSync("../app-config.json")) {
+    if (process.env.NODE_ENV === "development" && fs.existsSync("../app-config.json")) {
         appConfig = JSON.parse(fs.readFileSync("../app-config.json", 'utf8'));
+    } else if (fs.existsSync("app-config.json")) {
+        appConfig = JSON.parse(fs.readFileSync("app-config.json", 'utf8'));
     }
 
     const {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import btoa from "btoa";
 import fs from "fs";
 import { init } from "d2";
 import { configure } from "log4js";
+import * as yargs from "yargs";
 import "dotenv/config";
 
 import indexRouter from "./routes";
@@ -28,12 +29,20 @@ configure({
     categories: { default: { appenders: ["file"], level: "debug" } },
 });
 
+const { c: configFile } = yargs.options({
+    c: {
+        type: "string",
+        demandOption: true,
+        alias: "config",
+    },
+}).argv;
+
 const start = async (): Promise<void> => {
     let appConfig;
     if (process.env.NODE_ENV === "development" && fs.existsSync("../app-config.json")) {
-        appConfig = JSON.parse(fs.readFileSync("../app-config.json", 'utf8'));
-    } else if (fs.existsSync("app-config.json")) {
-        appConfig = JSON.parse(fs.readFileSync("app-config.json", 'utf8'));
+        appConfig = JSON.parse(fs.readFileSync("../app-config.json", "utf8"));
+    } else if (fs.existsSync(configFile)) {
+        appConfig = JSON.parse(fs.readFileSync(configFile, "utf8"));
     }
 
     const {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ const { c: configFile } = process.env.NODE_ENV !== "development" ? yargs.options
         demandOption: true,
         alias: "config",
     },
-}).argv : { c: "../app-config.json" };
+}).argv : { c: "./app-config.json" };
 
 const start = async (): Promise<void> => {
     let appConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,6 +877,11 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
+"@zeit/ncc@^0.20.4":
+  version "0.20.4"
+  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.20.4.tgz#00f0a25a88cac3712af4ba66561d9e281c6f05c9"
+  integrity sha512-fmq+F/QxPec+k/zvT7HiVpk7oiGFseS6brfT/AYqmCUp6QFRK7vZf2Ref46MImsg/g2W3g5X6SRvGRmOAvEfdA==
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -840,6 +840,18 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
+"@types/yargs-parser@*":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.0.0.tgz#453743c5bbf9f1bed61d959baab5b06be029b2d0"
+  integrity sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==
+
+"@types/yargs@^13.0.2":
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.2.tgz#a64674fc0149574ecd90ba746e932b5a5f7b3653"
+  integrity sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==
+  dependencies:
+    "@types/yargs-parser" "*"
+
 "@typescript-eslint/eslint-plugin@^1.12.0":
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.12.0.tgz#96b4e08b5f998a198b8414508b1a289f9e8c549a"
@@ -1198,6 +1210,11 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camelcase@^5.0.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
 caniuse-lite@^1.0.30000981:
   version "1.0.30000984"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000984.tgz#dc96c3c469e9bcfc6ad5bdd24c77ec918ea76fe0"
@@ -1278,6 +1295,15 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
+
+cliui@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
+  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
+  dependencies:
+    string-width "^3.1.0"
+    strip-ansi "^5.2.0"
+    wrap-ansi "^5.1.0"
 
 code-point-at@^1.0.0:
   version "1.1.0"
@@ -1460,6 +1486,11 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+decamelize@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -2012,6 +2043,11 @@ gauge@~2.7.3:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
+
+get-caller-file@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-stdin@^6.0.0:
   version "6.0.0"
@@ -3380,6 +3416,16 @@ repeat-string@^1.5.2, repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -3507,7 +3553,7 @@ serve-static@1.14.1:
     parseurl "~1.3.3"
     send "0.17.1"
 
-set-blocking@~2.0.0:
+set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -3687,7 +3733,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^3.0.0:
+string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
   integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
@@ -3717,7 +3763,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.1.0:
+strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -3948,6 +3994,11 @@ whatwg-fetch@>=0.10.0:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
 which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -3967,6 +4018,15 @@ wordwrap@~1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
+wrap-ansi@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+  dependencies:
+    ansi-styles "^3.2.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -3979,7 +4039,37 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
+y18n@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
+  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
 yallist@^3.0.0, yallist@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+
+yargs-parser@^13.1.1:
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
+  integrity sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.0.0.tgz#ba4cacc802b3c0b3e36a9e791723763d57a85066"
+  integrity sha512-ssa5JuRjMeZEUjg7bEL99AwpitxU/zWGAGpdj0di41pOEmJti8NR6kyUIJBkR78DTYNPZOU08luUo0GTHuB+ow==
+  dependencies:
+    cliui "^5.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.1"


### PR DESCRIPTION
### :pushpin: Description

In production instead of taking the whole project and installing the dependencies we can now provide a single executable file that can be executed with node.

### :memo: Implementation

- Add a new [dependency ](https://github.com/zeit/ncc) over ZEIT's bundle compiler ```ncc```. This dependency is used in their commercial product ```next.js``` and should be maintained regularly.

- Move configuration reading to ```fs.fileSync```, not using the async version to simplify the logic since we are reading a really small file.

- Update the yarn scripts to build the distributable file

### :fire: Is there anything the reviewer should know to test it?

```
yarn install
yarn dist
node metadata-synchronization-server.js
```

### :bookmark_tabs: Others

- Bundle size (minified): 1.400 MB
- Bundle size (original):  2.974 MB
- Project with dependencies size: 114 MB